### PR TITLE
Update local docker setup so it builds and registers with the Control Tower correctly

### DIFF
--- a/docker-compose-develop.yml
+++ b/docker-compose-develop.yml
@@ -7,11 +7,11 @@ services:
     container_name: rw-lp
     environment:
       PORT: 8080
-      CT_URL: http://localhost:9000
+      CT_URL: http://mymachine:9000
       CT_TOKEN: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6Im1pY3Jvc2VydmljZSIsImNyZWF0ZWRBdCI6IjIwMTYtMDktMTQifQ.IRCIRm1nfIQTfda_Wb6Pg-341zhV8soAgzw7dd5HxxQ
       API_VERSION: v1
       CT_REGISTER_MODE: auto
-      LOCAL_URL: http://mymachine:3000
+      LOCAL_URL: http://mymachine:8080
       FASTLY_ENABLED: "false"
     command: start
     restart: always


### PR DESCRIPTION
I have made a series of small changes which ensures that the microservices build and register with the Control Tower locally with Docker.

The changes to this repo are:
- Update config to use `mymachine` pattern for URLs